### PR TITLE
ENTRYPOINT: use it for easier arg passing

### DIFF
--- a/jessie/1.15.1/Dockerfile
+++ b/jessie/1.15.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/1.15.2/Dockerfile
+++ b/jessie/1.15.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/1.15.3/Dockerfile
+++ b/jessie/1.15.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/1.16.0/Dockerfile
+++ b/jessie/1.16.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/1.16.1/Dockerfile
+++ b/jessie/1.16.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/1.16.2/Dockerfile
+++ b/jessie/1.16.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/1.16.3/Dockerfile
+++ b/jessie/1.16.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/2.0.0/Dockerfile
+++ b/jessie/2.0.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/jessie/2.0.1/Dockerfile
+++ b/jessie/2.0.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.13.0/Dockerfile
+++ b/trusty/1.13.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.13.1/Dockerfile
+++ b/trusty/1.13.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.13.3/Dockerfile
+++ b/trusty/1.13.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.13.4/Dockerfile
+++ b/trusty/1.13.4/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.14.0/Dockerfile
+++ b/trusty/1.14.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.14.1/Dockerfile
+++ b/trusty/1.14.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.15.0/Dockerfile
+++ b/trusty/1.15.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.15.1/Dockerfile
+++ b/trusty/1.15.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.15.2/Dockerfile
+++ b/trusty/1.15.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.15.3/Dockerfile
+++ b/trusty/1.15.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.16.0/Dockerfile
+++ b/trusty/1.16.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.16.1/Dockerfile
+++ b/trusty/1.16.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.16.2/Dockerfile
+++ b/trusty/1.16.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/1.16.3/Dockerfile
+++ b/trusty/1.16.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/2.0.0/Dockerfile
+++ b/trusty/2.0.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/trusty/2.0.1/Dockerfile
+++ b/trusty/2.0.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/1.15.2/Dockerfile
+++ b/utopic/1.15.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/1.15.3/Dockerfile
+++ b/utopic/1.15.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/1.16.0/Dockerfile
+++ b/utopic/1.16.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/1.16.1/Dockerfile
+++ b/utopic/1.16.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/1.16.2/Dockerfile
+++ b/utopic/1.16.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/1.16.3/Dockerfile
+++ b/utopic/1.16.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/2.0.0/Dockerfile
+++ b/utopic/2.0.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/utopic/2.0.1/Dockerfile
+++ b/utopic/2.0.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.15.1/Dockerfile
+++ b/wheezy/1.15.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.15.2/Dockerfile
+++ b/wheezy/1.15.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.15.3/Dockerfile
+++ b/wheezy/1.15.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.16.0/Dockerfile
+++ b/wheezy/1.16.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.16.1/Dockerfile
+++ b/wheezy/1.16.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.16.2/Dockerfile
+++ b/wheezy/1.16.2/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/1.16.3/Dockerfile
+++ b/wheezy/1.16.3/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/2.0.0/Dockerfile
+++ b/wheezy/2.0.0/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080

--- a/wheezy/2.0.1/Dockerfile
+++ b/wheezy/2.0.1/Dockerfile
@@ -17,7 +17,9 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
-CMD ["rethinkdb", "--bind", "all"]
+ENTRYPOINT ["rethinkdb"]
+
+CMD ["--bind","all"]
 
 #   process cluster webui
 EXPOSE 28015 29015 8080


### PR DESCRIPTION
Using ENTRYPOINT with CMD allows for easier passing of additional arguments to container.

#### before (--help)
```
$ docker run -it rethinkdb --help
FATA[0000] Error response from daemon: Cannot start container 225130620f5a527dda793b49eb41ddb82e38ab6725025dcf67bbdf052fc1bdf3: [8] System error: exec: "--help": executable file not found in $PATH
```
#### after (--help)
```
$ docker run -it rethinkdb --help
Running 'rethinkdb' will create a new data directory or use an existing one,
  and serve as a RethinkDB cluster node.
File path options:
  -d [ --directory ] path                     specify directory to store data and
                                              metadata
[..snip..]
```
#### after (--join)
```
$ docker run -it rethinkdb --join rdb1.rethinkdb.com:29015
Recursively removing directory /data/rethinkdb_data/tmp
Initializing directory /data/rethinkdb_data
Running rethinkdb 2.0.1~0jessie (GCC 4.9.1)...
Running on Linux 3.13.0-48-generic x86_64
Loading data from directory /data/rethinkdb_data
Listening for intracluster connections on port 29015
Listening for client driver connections on port 28015
Listening for administrative HTTP connections on port 8080
Listening on addresses: 127.0.0.1, ::1
To fully expose RethinkDB on the network, bind to all addresses by running rethinkdb with the `--bind all` command line option.
Server ready, "576d0e2ecfbe_c3z" c5d83652-11e3-4739-ae19-dd345eb67f78
Connected to server "rdb1_rethinkdb_com_8fj" ffa2fa8c-75dc-4e70-96e9-d18e60541feb
```

Just like `--help` or `--join`, any other argument can be passed to container as it starts.